### PR TITLE
Fix header to revert to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,17 +6,13 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chatbot</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-title">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle dark/light theme" title="Toggle theme">
                     <svg class="theme-icon sun-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -68,39 +68,19 @@ body {
 /* Header */
 header {
     display: flex;
-    padding: 1.5rem 2rem;
-    background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
+    padding: 1rem 2rem;
+    background: var(--background);
     flex-shrink: 0;
 }
 
 /* Header Content Layout */
 .header-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     width: 100%;
 }
 
-.header-title {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {
@@ -808,10 +788,6 @@ details[open] .suggested-header::before {
         flex-direction: row;
         align-items: center;
         gap: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
     }
     
     .theme-toggle {


### PR DESCRIPTION
This PR reverts the header to a simpler, older version while keeping the theme toggle functionality.

## Changes:
- Remove "Course Materials Assistant" header text
- Remove subtitle "Ask questions about courses, instructors, and content"
- Remove horizontal border line below header
- Keep theme toggle functionality preserved
- Update page title to "RAG Chatbot"
- Simplify header layout with theme toggle positioned on the right

Fixes #2

Generated with [Claude Code](https://claude.ai/code)